### PR TITLE
wp thread context

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
   implementation("org.apache.commons:commons-compress:1.22")
   implementation("org.slf4j:slf4j-api:1.7.36")
+  implementation("org.apache.logging.log4j:log4j-api-kotlin:1.2.0")
 
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
   testImplementation("org.mockito:mockito-core:5.2.0")

--- a/src/main/kotlin/org/veupathdb/vdi/lib/common/async/WorkerPool.kt
+++ b/src/main/kotlin/org/veupathdb/vdi/lib/common/async/WorkerPool.kt
@@ -4,6 +4,9 @@ import org.slf4j.LoggerFactory
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
+import org.apache.logging.log4j.kotlin.CoroutineThreadContext
+import org.apache.logging.log4j.kotlin.ThreadContextData
+import java.util.*
 
 class WorkerPool(
   private val name: String,
@@ -25,7 +28,16 @@ class WorkerPool(
     runBlocking {
       repeat(workerCount) {
         val j = ++i
-        launch {
+        launch (CoroutineThreadContext(
+          contextData = ThreadContextData(
+            map = mapOf(
+              Pair(
+                "workerID",
+                "$name-$j"
+              )
+            ), Stack()
+          )
+        )) {
           log.debug("worker pool {} starting worker #{}", name, j)
 
           while (!shutdown.isTriggered()) {

--- a/src/main/kotlin/org/veupathdb/vdi/lib/common/async/WorkerPool.kt
+++ b/src/main/kotlin/org/veupathdb/vdi/lib/common/async/WorkerPool.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import org.apache.logging.log4j.kotlin.CoroutineThreadContext
 import org.apache.logging.log4j.kotlin.ThreadContextData
+import org.apache.logging.log4j.kotlin.logger
 import java.util.*
 
 class WorkerPool(
@@ -13,7 +14,7 @@ class WorkerPool(
   private val jobQueueSize: Int,
   private val workerCount: Int = 5,
 ) {
-  private val log = LoggerFactory.getLogger(javaClass)
+  private val log = logger()
 
   private val shutdown = ShutdownSignal()
   private val queue    = Channel<Job>(jobQueueSize)
@@ -22,7 +23,7 @@ class WorkerPool(
 
   @OptIn(ExperimentalCoroutinesApi::class)
   fun start() {
-    log.info("starting worker pool {} with queue size {} and worker count {}", name, jobQueueSize, workerCount)
+    log.info("starting worker pool $name with queue size $jobQueueSize and worker count $workerCount")
 
     var i = 0
     runBlocking {
@@ -38,11 +39,11 @@ class WorkerPool(
             ), Stack()
           )
         )) {
-          log.debug("worker pool {} starting worker #{}", name, j)
+          log.debug("worker pool $name starting worker $j")
 
           while (!shutdown.isTriggered()) {
             if (!queue.isEmpty) {
-              log.debug("worker pool {} executing job {}", name, ++jobs)
+              log.debug("worker pool $name executing job ${++jobs}")
               val job = queue.receive()
 
               try {
@@ -56,7 +57,7 @@ class WorkerPool(
             }
           }
 
-          log.debug("worker pool {} shutting down worker #{}", name, j)
+          log.debug("worker pool $name shutting down worker $j")
           count.decrement()
         }
       }

--- a/src/main/kotlin/org/veupathdb/vdi/lib/common/compression/Tar.kt
+++ b/src/main/kotlin/org/veupathdb/vdi/lib/common/compression/Tar.kt
@@ -3,6 +3,7 @@ package org.veupathdb.vdi.lib.common.compression
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.apache.logging.log4j.kotlin.logger
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
 import java.util.zip.GZIPInputStream
@@ -10,18 +11,18 @@ import java.util.zip.GZIPOutputStream
 import kotlin.io.path.*
 
 object Tar {
-  private val log = LoggerFactory.getLogger(javaClass)
+  private val log = logger()
 
   fun compressWithGZip(output: Path, inputs: Collection<Path>) {
-    log.trace("compressWithGZip(output={}, inputs={})", output, inputs)
+    log.trace("compressWithGZip(output=$output, inputs=$inputs)")
 
     if (output.exists())
       throw IllegalStateException("target output path already exists!")
 
-    log.debug("opening tar.gz output stream to path {}", output)
+    log.debug("opening tar.gz output stream to path $output")
     TarArchiveOutputStream(GZIPOutputStream(output.outputStream().buffered())).use { tar ->
       inputs.forEach { file ->
-        log.debug("compressing input file {}", file)
+        log.debug("compressing input file $file")
         tar.putArchiveEntry(TarArchiveEntry(file, file.name))
         file.inputStream().use { inp -> inp.transferTo(tar) }
         tar.closeArchiveEntry()
@@ -31,14 +32,14 @@ object Tar {
   }
 
   fun decompressWithGZip(inputFile: Path, outputDir: Path) {
-    log.trace("decompressWithGZip(outputDir={})", outputDir)
+    log.trace("decompressWithGZip(outputDir=$outputDir)")
 
     if (!outputDir.exists())
       outputDir.createDirectories()
     if (!outputDir.isDirectory())
       throw IllegalStateException("target output path does not point to a directory")
 
-    log.debug("unpacking input tar.gz file {} into output directory {}", inputFile, outputDir)
+    log.debug("unpacking input tar.gz file $inputFile into output directory $outputDir")
     TarArchiveInputStream(GZIPInputStream(inputFile.inputStream().buffered())).use { tar ->
       tar.forEach { entry ->
         val target = outputDir.resolve(entry.name)


### PR DESCRIPTION
- Add worker pool identifier to thread context
- Update to kotlin logger

This is to improve debugging of an issue I'm running into while testing where import seems to be getting stuck or failing somewhere.