### PR TITLE
Adds dataset visibility field

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "org.veupathdb.vdi"
-version = "1.0.0-SNAPSHOT"
+version = "1.0.0"
 description = "Common components for VDI projects"
 
 repositories {

--- a/src/main/kotlin/org/veupathdb/vdi/lib/common/model/VDIDatasetMeta.kt
+++ b/src/main/kotlin/org/veupathdb/vdi/lib/common/model/VDIDatasetMeta.kt
@@ -16,6 +16,10 @@ interface VDIDatasetMeta {
   @set:JsonSetter(JsonKey.Projects)
   var projects: Set<ProjectID>
 
+  @get:JsonGetter(JsonKey.Visibility)
+  @set:JsonSetter(JsonKey.Visibility)
+  var visibility: VDIDatasetVisibility
+
   @get:JsonGetter(JsonKey.Owner)
   @set:JsonSetter(JsonKey.Owner)
   var owner: UserID
@@ -44,6 +48,6 @@ interface VDIDatasetMeta {
     const val Projects     = "projects"
     const val Summary      = "summary"
     const val Type         = "type"
+    const val Visibility   = "visibility"
   }
 }
-

--- a/src/main/kotlin/org/veupathdb/vdi/lib/common/model/VDIDatasetMetaImpl.kt
+++ b/src/main/kotlin/org/veupathdb/vdi/lib/common/model/VDIDatasetMetaImpl.kt
@@ -11,6 +11,9 @@ data class VDIDatasetMetaImpl(
   @JsonProperty(VDIDatasetMeta.JsonKey.Projects)
   override var projects: Set<ProjectID>,
 
+  @JsonProperty(VDIDatasetMeta.JsonKey.Visibility)
+  override var visibility: VDIDatasetVisibility,
+
   @JsonProperty(VDIDatasetMeta.JsonKey.Owner)
   override var owner: UserID,
 

--- a/src/main/kotlin/org/veupathdb/vdi/lib/common/model/VDIDatasetVisibility.kt
+++ b/src/main/kotlin/org/veupathdb/vdi/lib/common/model/VDIDatasetVisibility.kt
@@ -1,0 +1,38 @@
+package org.veupathdb.vdi.lib.common.model
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class VDIDatasetVisibility {
+  Private,
+  Protected,
+  Public,
+  ;
+
+  @get:JsonValue
+  val value
+    get() = when (this) {
+      Private   -> "private"
+      Protected -> "protected"
+      Public    -> "public"
+    }
+
+  companion object {
+    @JvmStatic
+    @JsonCreator
+    fun fromString(value: String) =
+      fromStringOrNull(value)
+        ?: throw IllegalArgumentException("Unrecognized VDIDatasetVisibility value: $value")
+
+    @JvmStatic
+    fun fromStringOrNull(value: String): VDIDatasetVisibility? {
+      val value = value.lowercase()
+
+      for (enum in values())
+        if (value == enum.value)
+          return enum
+
+      return null
+    }
+  }
+}


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE**  Consumers of the new version of this library will need to make use of the new field when constructing Metadata instances otherwise they will face compile errors.

Additionally, this PR switches the versioning from snapshot to concrete versions.  This will mark the first "official" release of the library, meaning both consuming VDI projects will need to be manually updated to use this version.