### PR TITLE
Support monitoring of WorkerPool queue size

### DIFF
--- a/src/main/kotlin/org/veupathdb/vdi/lib/common/async/WorkerPool.kt
+++ b/src/main/kotlin/org/veupathdb/vdi/lib/common/async/WorkerPool.kt
@@ -12,6 +12,7 @@ class WorkerPool(
   private val name: String,
   private val jobQueueSize: Int,
   private val workerCount: Int = 5,
+  private val reportQueueSizeChange: (Int) -> Unit = { }
 ) {
   private val log = logger()
 
@@ -35,6 +36,7 @@ class WorkerPool(
             if (!queue.isEmpty) {
               log.debug("worker $name-$j executing job ${++jobs}")
               val job = queue.receive()
+              reportQueueSizeChange(-1) // Report one less job in queue.
 
               try {
                 job()
@@ -56,6 +58,7 @@ class WorkerPool(
 
   suspend fun submit(job: Job) {
     queue.send(job)
+    reportQueueSizeChange(1) // Report one more job in queue.
   }
 
   suspend fun stop() {


### PR DESCRIPTION
Adding a hook to monitor the worker pool size. Passing a function instead of a prometheus gauge to avoid depending on prometheus in this library.